### PR TITLE
Support any types of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ You can directly accumulate the residuals and jacobians this way:
   auto loss = [](const auto &x, auto &JtJ, auto &Jt_res) {
     float res = x * x - 2; // since we want x to be sqrt(2), x*x should be 2
     float J   = 2 * x; // residual's jacobian/derivative w.r.t x
-    // Manually update JtJ and Jt*err (a.k.a gradient)
-    JtJ(0, 0) = J * J;
-    Jt_res(0) = J * res; // gradient
+    // Manually update JtJ and Jt*err
+    JtJ(0, 0) = J * J;   // normal matrix
+    Jt_res(0) = J * res; // gradient (half of it actually)
     // Return both the squared error and the number of residuals (here, we have only one)
     return std::make_pair(res*res, 1);
   };

--- a/README.md
+++ b/README.md
@@ -27,16 +27,17 @@ Here are a few ways to call `tinyopt`.
 
 `tinyopt` is developer friendly, just call `Optimize` and give it something to optimize, say `x` and something to minimize.
 
-`Optimize` performs automatic differentiation so you just have to specify the residual(s), no jacodians/drivatives to calculate because you know the pain, right? No pain, vanished, thank you Julien.
+`Optimize` performs automatic differentiation so you just have to specify the residual(s),
+no jacodians/derivatives to calculate because you know the pain, right? No pain, vanished, thank you Julien.
 
 ### What's the square root of 2?
 Beause using `std::sqrt` is over hyped, let's try to recover it using `tinyopt`, here is how to do:
 
 ```cpp
-  // Define 'x', the parameter to optimize, initialized to '1' (yeah, who doesn't like 1?)
-  double x = 1;
-  Optimize(x,  [](const auto &x) {return x * x - 2.0;}); // Let's minimize ε = x*x - 2
-  // 'x' is now std::sqrt(2.0), amazing.
+// Define 'x', the parameter to optimize, initialized to '1' (yeah, who doesn't like 1?)
+double x = 1;
+Optimize(x,  [](const auto &x) {return x * x - 2.0;}); // Let's minimize ε = x*x - 2
+// 'x' is now std::sqrt(2.0), amazing.
 ```
 That's it. Is it too verbose? Well remove the comments then. Come on, it's just two lines, I can't do better.
 
@@ -45,59 +46,135 @@ In this use case, you're given `n` 2D points your job is to fit a circle to them
 Today is your lucky day, `tinyopt` is here to help! Let's see how.
 
 ```cpp
-  Mat2Xf obs(2, n); // fill the observations (n 2D points)
+Mat2Xf obs(2, n); // fill the observations (n 2D points)
 
-  // loss is the sum of || ||p - center||² - radius² ||
-  auto loss = [&obs]<typename T>(const Eigen::Vector<T, 3> &x) {
-    const auto &center = x.template head<2>(); // the first two elements are the cicle position
-    const auto radius2 = x.z() * x.z(); // the last one is its radius, taking the square to avoid a sqrt later on
-    // Here we compute the squared distances of each point to the center
-    auto residuals = (obs.cast<T>().colwise() - center).colwise().squaredNorm();
-    // Here we compute the difference of of squared distances are the circle's squared radius
-    return (residuals.array() - radius2).matrix().transpose().eval();
-    // Make sure the returned type is a scalar or Eigen::Vector<T, N> (thus the .eval())
-  };
+// loss is the sum of || ||p - center||² - radius² ||
+auto loss = [&obs]<typename T>(const Eigen::Vector<T, 3> &x) {
+  const auto &center = x.template head<2>(); // the first two elements are the cicle position
+  const auto radius2 = x.z() * x.z(); // the last one is its radius, taking the square to avoid a sqrt later on
+  // Here we compute the squared distances of each point to the center
+  auto residuals = (obs.cast<T>().colwise() - center).colwise().squaredNorm();
+  // Here we compute the difference of of squared distances are the circle's squared radius
+  return (residuals.array() - radius2).matrix().transpose().eval();
+  // Make sure the returned type is a scalar or Eigen::Vector<T, N> (thus the .eval())
+};
 
 
-  // Define 'x', the parameter to optimize, using the following parametrization: x = {center (x, y), radius}
-  Vec3 x(0, 0, 1);
-  Optimize(x, loss); // Optimize!
-  // 'x' should have converged to a reasonable cicle
-  std::cout << "Residuals: " << loss(x) << "\n"; // Let's print the final residuals
+// Define 'x', the parameter to optimize, using the following parametrization: x = {center (x, y), radius}
+Vec3 x(0, 0, 1);
+Optimize(x, loss); // Optimize!
+// 'x' should have converged to a reasonable cicle
+std::cout << "Residuals: " << loss(x) << "\n"; // Let's print the final residuals
 ```
 
-Ok so this is quite more verbose then in the first example but I'm trying to help you understand the syntax, it's easy no?
+Ok so this is quite more verbose than in the first example but I'm trying to help you understand the syntax, it's easy no?
 
 ## Advanced API
+
+### Direct Accumulation, a faster - but manual - way.
 
 When working with more whan one residuals, `tinyopt` allows you to avoid storing a full vector of residuals.
 You can directly accumulate the residuals and jacobians this way:
 
 ```cpp
 
-  // Define 'x', the parameter to optimize, initialized to '1'
-  double x = 1;
+// Define 'x', the parameter to optimize, initialized to '1'
+double x = 1;
 
-  // Define the residuals / loss function, here ε² = ||x*x - 2||²
-  auto loss = [](const auto &x, auto &JtJ, auto &Jt_res) {
-    float res = x * x - 2; // since we want x to be sqrt(2), x*x should be 2
-    float J   = 2 * x; // residual's jacobian/derivative w.r.t x
-    // Manually update JtJ and Jt*err
-    JtJ(0, 0) = J * J;   // normal matrix
-    Jt_res(0) = J * res; // gradient (half of it actually)
-    // Return both the squared error and the number of residuals (here, we have only one)
-    return std::make_pair(res*res, 1);
-  };
+// Define the residuals / loss function, here ε² = ||x*x - 2||²
+auto loss = [](const auto &x, auto &JtJ, auto &Jt_res) {
+  float res = x * x - 2; // since we want x to be sqrt(2), x*x should be 2
+  float J   = 2 * x; // residual's jacobian/derivative w.r.t x
+  // Manually update JtJ and Jt*err
+  JtJ(0, 0) = J * J;   // normal matrix
+  Jt_res(0) = J * res; // gradient (half of it actually)
+  // Return both the squared error and the number of residuals (here, we have only one)
+  return std::make_pair(res*res, 1);
+};
 
-  // Setup optimizer options (optional)
-  Options options;
-  // Optimize!
-  const auto &out = Optimize(x, loss, options);
-  // 'x' is now std::sqrt(2.0), you can check the convergence with out.Converged()
+// Setup optimizer options (optional)
+Options options;
+// Optimize!
+const auto &out = Optimize(x, loss, options);
+// 'x' is now std::sqrt(2.0), you can check the convergence with out.Converged()
 ```
 
-* `JtJ` and `Jt_res` the only thing you need to update for LM to solve the normal equations and optimize `x`.
-It looks a bit rural but we can't all live in a city with a sleek landspace, sometime it's good to back to your (square) roots so take your boots and start coding.
+`JtJ` and `Jt_res` are the only things you need to update for LM to solve the normal equations and optimize `x`.
+It looks a bit rural I know but we can't all live in a city with sleek buidlings,
+sometimes it's good to go back to your (square) roots, so take your boots and start coding.
+
+### User defined parameters
+
+Let's say you have a fancy class/struct, say a `Rectangle` and you want to optimize its dimensions.
+For instance,
+
+```cpp
+template <typename T> // Template is only needed if you need automatic differentiation
+struct Rectangle {
+  T area() const { return (p2 - p1).norm(); }
+  T width() const { return p2.x() - p1.x(); }
+  T height() const { return p2.y() - p1.y(); }
+  Eigen::Vector<T, 2> center() const { return T(0.5) * (p1 + p2); }
+  Eigen::Vector<T, 2> p1, p2; // top left and bottom right positions
+};
+```
+
+Now if you wan to simply call `Optimize(rectangle, loss)` on your rectangle struct, you need to add
+a trait specialization of `params_trait` for you object type:
+
+```cpp
+
+namespace tinyopt::traits { // must be defined in tinyopt::traits
+
+template <typename T>
+struct params_trait<Rectangle<T>> {
+  using Scalar = T;              // The scalar type
+  static constexpr int Dims = 4; // Compile-time parameters dimensions
+  static constexpr int dims(const Rectangle<T> &) { return Dims; } // // Execution-time parameters dimensions
+  // Conversion to string (for logging)
+  static std::string toString(const Rectangle<T> &rect) {
+    std::stringstream os;
+    os << "p1:" << rect.p1.transpose() << ", p2:" << rect.p2.transpose();
+    return os.str();
+  }
+
+  // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>
+  // Not needed if you use manual Jacobians instead of automatic differentiation
+  template <typename T2> static Rectangle<T2> cast(const Rectangle<T> &rect) {
+    return Rectangle<T2>(rect.p1.template cast<T2>(),
+                         rect.p2.template cast<T2>());
+  }
+
+  // Define how to update the object members (parametrization and manifold)
+  static void pluseq(Rectangle<T> &rect,
+                     const Eigen::Vector<Scalar, Dims> &delta) {
+    // In this case delta is defined as 2 deltas for p1 and p2: [dx1, dy1, dx2, dy2]
+    rect.p1 += delta.template head<2>();
+    rect.p2 += delta.template tail<2>();
+  }
+};
+
+} // namespace tinyopt::traits
+```
+Now you can start optimizing your custom object, e.g.
+
+```cpp
+// Let's say I want the rectangle area to be 10*20, the width = 2 * height and
+// the center at (1, 2).
+auto loss = [&]<typename T>(const Rectangle<T> &rect) {
+  using std::max;
+  Eigen::Vector<T, 4> residuals;
+  residuals[0] = rect.area() - 10.0f * 20.0f;
+  residuals[1] = 100.0f * (rect.width() / max(rect.height(), T(1e-8f)) -
+                            2.0f); // the 1e-8 is to prevent division by 0
+  residuals.template tail<2>() = rect.center() - Eigen::Vector<T, 2>(1, 2);
+  return residuals;
+};
+
+Rectangle rectangle;
+Optimize(rectangle, loss);
+// That's it, rectangle is now fitted to your loss
+```
 
 # Testing
 
@@ -124,7 +201,7 @@ All tests passed (2 assertions in 1 test case)
 
 Here is what is coming up:
 
-- [ ] Add custom parameter struct with manifold example
+- [x] Add custom parameter struct with manifold example
 - [ ] Add more tests (inf, nan, etc.)
 - [ ] Add examples
 - [ ] Add benchmarks

--- a/include/tinyopt/log.h
+++ b/include/tinyopt/log.h
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#include <sstream>
+
+#include "traits.h"
+
+
 #if HAS_FMT
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -30,3 +35,26 @@
 #define TINYOPT_FORMAT(str, ...) str // c++ < 2020 not well supported for now
 
 #endif
+
+namespace tinyopt {
+
+// Default toString
+template <typename T>
+std::string toString(const T& value) {
+  std::stringstream ss;
+  ss << value;
+  return ss.str();
+}
+
+// Specialization for Eigen Matrix
+template <typename T>
+std::string toString(const Eigen::MatrixBase<T> &m) {
+  std::stringstream ss;
+  if (m.cols() == 1)
+    ss << m.transpose();
+  else
+    ss << m;
+  return ss.str();
+};
+
+} // namespace tinyopt

--- a/include/tinyopt/log.h
+++ b/include/tinyopt/log.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <sstream>
 
 #include "traits.h"
 
@@ -38,23 +37,9 @@
 
 namespace tinyopt {
 
-// Default toString
 template <typename T>
-std::string toString(const T& value) {
-  std::stringstream ss;
-  ss << value;
-  return ss.str();
+std::string toString(const T& v) {
+  return traits::params_trait<T>::toString(v);
 }
-
-// Specialization for Eigen Matrix
-template <typename T>
-std::string toString(const Eigen::MatrixBase<T> &m) {
-  std::stringstream ss;
-  if (m.cols() == 1)
-    ss << m.transpose();
-  else
-    ss << m;
-  return ss.str();
-};
 
 } // namespace tinyopt

--- a/include/tinyopt/math.h
+++ b/include/tinyopt/math.h
@@ -17,8 +17,6 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
-#include <sstream>
-
 namespace tinyopt {
 
 static constexpr int Dynamic = Eigen::Dynamic;
@@ -38,23 +36,6 @@ InvCov(const Derived &m) {
       Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>;
   const auto chol = Eigen::SelfAdjointView<const Derived, Eigen::Upper>(m).ldlt();
   return chol.solve(MatType::Identity(m.rows(), m.cols()));
-}
-
-// Convert a matrix to a string using default formatting
-template <typename Derived>
-std::string toString(const Eigen::MatrixBase<Derived> &m) {
-  std::stringstream ss;
-  if (m.cols() == 1)
-    ss << m.transpose();
-  else
-    ss << m;
-  return ss.str();
-}
-
-inline std::string toString(const double &m) {
-  std::stringstream ss;
-  ss << m;
-  return ss.str();
 }
 
 } // namespace tinyopt

--- a/include/tinyopt/traits.h
+++ b/include/tinyopt/traits.h
@@ -23,6 +23,12 @@
 
 namespace tinyopt::traits {
 
+// Check whether a type 'T' or '&T' is nullptr_t
+template <typename T>
+struct is_nullptr_type : std::is_same<std::remove_reference_t<T>, std::nullptr_t> {};
+template <typename T>
+inline constexpr bool is_nullptr_type_v = is_nullptr_type<T>::value;
+
 // Trait to check if a type is an Eigen matrix
 template <typename T>
 struct is_eigen_matrix_or_array

--- a/include/tinyopt/traits.h
+++ b/include/tinyopt/traits.h
@@ -55,7 +55,7 @@ template <typename T, typename = void> struct params_trait {
   }
 
   // Define update / manifold
-  static void pluseq(T& v, const Eigen::Vector<T, Dims>& delta) {
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
     v += delta;
   }
 };
@@ -77,10 +77,10 @@ struct params_trait<T, std::enable_if_t<std::is_scalar_v<T>>> {
     return T2(v);
   }
   // Define update / manifold
-  static void pluseq(T& v, const Eigen::Vector<T, Dims>& delta) {
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
     v += delta[0];
   }
-  static void pluseq(T& v, const T& delta) {
+  static void pluseq(T& v, const Scalar& delta) {
     v += delta;
   }
 };
@@ -108,7 +108,7 @@ struct params_trait<
     return v.template cast<T2>();
   }
   // Define update / manifold
-  static void pluseq(T& v, const Eigen::Vector<T, Dims>& delta) {
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
     v += delta;
   }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,7 @@ target_link_libraries(tinyopt_test_fit_circle PRIVATE ${THIRDPARTY_TEST_LIBS})
 add_executable(tinyopt_test_userdef_params userdef_params.cpp)
 add_test(NAME tinyopt_test_userdef_params COMMAND tinyopt_test_userdef_params)
 target_link_libraries(tinyopt_test_userdef_params PRIVATE ${THIRDPARTY_TEST_LIBS})
+
+add_executable(tinyopt_test_userdef_params_jet userdef_params_jet.cpp)
+add_test(NAME tinyopt_test_userdef_params_jet COMMAND tinyopt_test_userdef_params_jet)
+target_link_libraries(tinyopt_test_userdef_params_jet PRIVATE ${THIRDPARTY_TEST_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,3 +6,7 @@ target_link_libraries(tinyopt_test_sqrt2 PRIVATE ${THIRDPARTY_TEST_LIBS})
 add_executable(tinyopt_test_fit_circle circle.cpp)
 add_test(NAME tinyopt_test_fit_circle COMMAND tinyopt_test_fit_circle)
 target_link_libraries(tinyopt_test_fit_circle PRIVATE ${THIRDPARTY_TEST_LIBS})
+
+add_executable(tinyopt_test_userdef_params userdef_params.cpp)
+add_test(NAME tinyopt_test_userdef_params COMMAND tinyopt_test_userdef_params)
+target_link_libraries(tinyopt_test_userdef_params PRIVATE ${THIRDPARTY_TEST_LIBS})

--- a/tests/circle.cpp
+++ b/tests/circle.cpp
@@ -66,7 +66,6 @@ void TestFitCircle() {
   REQUIRE(x.z() == Approx(radius).epsilon(1e-5));
 }
 
-
 TEST_CASE("tinyopt_fitcircle") {
   TestFitCircle();
 }

--- a/tests/userdef_params.cpp
+++ b/tests/userdef_params.cpp
@@ -108,7 +108,6 @@ void TestUserDefinedParameters() {
 
   std::nullptr_t null;
 
-
   std::cout << "rect:" << "area:" << rectangle.area()
             << ", c:" << rectangle.center().transpose()
             << ", size:" << rectangle.height() << "x" << rectangle.width()

--- a/tests/userdef_params.cpp
+++ b/tests/userdef_params.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2025 Julien Michot. All Rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <ostream>
+
+#include <Eigen/Eigen>
+
+#if CATCH2_VERSION == 2
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include "tinyopt/tinyopt.h"
+
+using namespace tinyopt;
+
+using Catch::Approx;
+
+
+// Example of a rectangle
+template <typename T> struct Rectangle {
+  using Vec2 = Eigen::Vector<T, 2>; // Just for convenience
+  explicit Rectangle() : p1(Vec2::Zero()), p2(Vec2::Zero()) {}
+
+  // Returns the area of the rectangle
+  T area() const { return (p2 - p1).norm(); }
+
+  // Returns the width of the rectangle
+  T width() const { return p2.x() - p1.x(); }
+  // Returns the width of the rectangle
+  T height() const { return p2.y() - p1.y(); }
+
+  // Returns the center of the rectangle
+  Vec2 center() const { return T(0.5) * (p1 + p2); }
+
+  // Define how to print the class [NEEDED]
+  friend std::ostream& operator<<(std::ostream& os, const Rectangle& rect) {
+    os << "p1:" << rect.p1.transpose() << ", p2:" << rect.p2.transpose() << std::endl;
+    return os;
+  }
+  Vec2 p1, p2; // top left and bottom right positions
+};
+
+
+// Example of a rectangle with parametrization
+template <typename T> struct RectangleParams : Rectangle<T> {
+  using Scalar = T; // Scalar (will be replaced by a Jet if automatic differentiation is used)
+  static constexpr int Dims = 4; // Number of dimensions (compile time), here 4
+
+  explicit RectangleParams() : Rectangle<T>() {}
+
+  // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>, used by auto differentiation
+  template <typename T2>
+  RectangleParams<T2> cast() const {
+    RectangleParams<T2> rect;
+    rect.p1 = this->p1.template cast<T2>();
+    rect.p2 = this->p2.template cast<T2>();
+    return rect;
+  }
+
+  // Define update / manifold
+  RectangleParams& operator+=(const Eigen::Vector<T, 4>& delta) {
+    // Here I'm choosing a non trivial parametrization (delta center x, delta center y, delta width, delta height)
+    // It would have been simpler to do p1 += delta.head<2>(), p2 += delta.tail<2>() but I want
+    // to illustrate a different parametrization.
+    this->p1.x() += delta[0];
+    this->p2.x() += delta[0] + delta[2]; // += dx + dw
+    this->p1.y() += delta[1];
+    this->p2.y() += delta[1] + delta[3]; // += dy + dh
+    return *this;
+  }
+
+  // Returns the rectangle dimensions at execution time (here same as at compile time) [NEEDED]
+  int dims() const { return Dims; }
+};
+
+
+void TestUserDefinedParameters1() {
+
+  // Let's say I want the rectangle area to be 10*20, the width = 2 * height and
+  // the center at (1, 2).
+  auto loss = [&]<typename T>(const Rectangle<T> &rect) {
+    Eigen::Vector<T, 3> residuals;
+    residuals[0] = rect.area() - 10 * 20;
+    residuals[1] = rect.width() / (rect.height() + 1e-8) - 2; // the 1e-8 is to prevent division by 0
+    residuals[2] = (rect.center() - Eigen::Vector<T, 2>(1, 2)).squaredNorm();
+    return residuals;
+  };
+
+  RectangleParams<float> rectangle;
+  const auto &out = Optimize(rectangle, loss);
+  REQUIRE(out.Succeeded());
+  REQUIRE(rectangle.area() == Approx(10 * 20).epsilon(1e-5));
+  REQUIRE(rectangle.center().x() == Approx(1).epsilon(1e-5));
+  REQUIRE(rectangle.center().y() == Approx(2).epsilon(1e-5));
+  REQUIRE(rectangle.width() == Approx(2 * rectangle.height()).epsilon(1e-5));
+}
+
+// TODO test with Rectangle + only traits/specializations
+// ideally I just define cast + operator+=(const Eigen::Vector<T, 4>& delta) are recover the Dims!
+
+TEST_CASE("tinyopt_userdef_params") {
+  TestUserDefinedParameters1();
+  // TODO TestUserDefinedParameters2
+}


### PR DESCRIPTION
Add support for optimization of custom object types.
Any object can be optimized providing the user define a specialization of `tinyopt::traits::params_trait` for the type with specific members and static functions.
Here is a example of specialization of a Rectangle struct:

```cpp

namespace tinyopt::traits { // must be defined in tinyopt::traits

template <typename T>
struct params_trait<Rectangle<T>> {
  using Scalar = T;              // The scalar type
  static constexpr int Dims = 4; // Compile-time parameters dimensions
  static constexpr int dims(const Rectangle<T> &) { return Dims; } // // Execution-time parameters dimensions
  // Conversion to string (for logging)
  static std::string toString(const Rectangle<T> &rect) {
    std::stringstream os;
    os << "p1:" << rect.p1.transpose() << ", p2:" << rect.p2.transpose();
    return os.str();
  }

  // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>
  // Not needed if you use manual Jacobians instead of automatic differentiation
  template <typename T2> static Rectangle<T2> cast(const Rectangle<T> &rect) {
    return Rectangle<T2>(rect.p1.template cast<T2>(),
                         rect.p2.template cast<T2>());
  }

  // Define how to update the object members (parametrization and manifold)
  static void pluseq(Rectangle<T> &rect,
                     const Eigen::Vector<Scalar, Dims> &delta) {
    // In this case delta is defined as 2 deltas for p1 and p2: [dx1, dy1, dx2, dy2]
    rect.p1 += delta.template head<2>();
    rect.p2 += delta.template tail<2>();
  }
};

} // namespace tinyopt::traits
```

The struct Rectangle `rectangle` can now be optimized directly using e.g. `Optimize(rectangle, ...)`