### PR TITLE
Support STL and Matrix parameters types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ std::cout << "Residuals: " << loss(x) << "\n"; // Let's print the final residual
 
 Ok so this is quite more verbose than in the first example but I'm trying to help you understand the syntax, it's easy no?
 
+## Supported Types
+
+With `tinyopt`, you can directly optimize several types of parameters `x`, namely
+
+* `float` or `double` scalar types
+* `std:array` of scalars
+* `std::vector` of a scalars
+* `Eigen::Vector` of fixed or dynamic size
+* `Eigen::Matrix` of fixed or dynamic size
+* Your custorm class or struct, see below
+
+`tinyopt` will detect whether the size is known at compile time and use optimized data structs to make the optimization faster.
+
+Residuals of the following types can also be returned
+
+* `float` or `double`
+* `Eigen::Vector` or `Eigen::Matrix`
+
 ## Advanced API
 
 ### Direct Accumulation, a faster - but manual - way.
@@ -129,8 +147,8 @@ namespace tinyopt::traits { // must be defined in tinyopt::traits
 template <typename T>
 struct params_trait<Rectangle<T>> {
   using Scalar = T;              // The scalar type
-  static constexpr int Dims = 4; // Compile-time parameters dimensions
-  static constexpr int dims(const Rectangle<T> &) { return Dims; } // // Execution-time parameters dimensions
+  static constexpr int Dims = 4; // Compile-time parameters dimensions (use Eigen::Dynamic if unknown)
+  static constexpr int dims(const Rectangle<T> &) { return Dims; } // Execution-time parameters dimensions (optional if Dims is known)
   // Conversion to string (for logging)
   static std::string toString(const Rectangle<T> &rect) {
     std::stringstream os;
@@ -141,6 +159,9 @@ struct params_trait<Rectangle<T>> {
   // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>
   // Not needed if you use manual Jacobians instead of automatic differentiation
   template <typename T2> static Rectangle<T2> cast(const Rectangle<T> &rect) {
+    // NOTE, for casting, use StaticCast<T2>(rect.xxx, total dimensions) if xxx is a dynamic type
+    // i.e. std::vector or Eigen::Dynamic size.
+    // e.g. StaticCast<T2>(rect.p1, 4) instead of rect.p1.template cast<T2>()
     return Rectangle<T2>(rect.p1.template cast<T2>(),
                          rect.p2.template cast<T2>());
   }

--- a/include/tinyopt/3rdparty/ceres/jet.h
+++ b/include/tinyopt/3rdparty/ceres/jet.h
@@ -220,27 +220,17 @@ struct Jet {
   Jet() : a() { v.setConstant(Scalar()); }
 
   // Constructor from scalar: a + 0. (only if N != Dynamic)
-  //template <std::enable_if_t<(N != Eigen::Dynamic), int> = 0>
   explicit Jet(const T& value) {
     a = value;
     v.setConstant(Scalar());
   }
 
   // Constructor from scalar plus variable: a + t_i. (only if N != Dynamic)
-  //template <std::enable_if_t<(N != Eigen::Dynamic), int> = 0>
   Jet(const T& value, int k) {
     a = value;
     v.setConstant(Scalar());
     v[k] = T(1.0);
   }
-
-  // Constructor from scalar: a + 0. (only if N == Dynamic)
-  /*template <std::enable_if_t<(N == Eigen::Dynamic), int> = 0>
-  Jet(const T& value, int dims) {
-    a = value;
-    v.reshape(dims, 1);
-    v.setConstant(Scalar());
-  }*/
 
   // Constructor from scalar and vector part
   // The use of Eigen::DenseBase allows Eigen expressions

--- a/include/tinyopt/gn.h
+++ b/include/tinyopt/gn.h
@@ -38,7 +38,7 @@ struct Options {
   bool JtJ_is_full = true;  // Specify if JtJ is only Upper triangularly or fully filled
   // Stops criteria
   uint16_t num_iters = 100;         // Maximum number of iterations
-  float min_delta_norm2 = 1e-12;    // Minimum delta (step) squared norm
+  float min_delta_norm2 = 0;        // Minimum delta (step) squared norm
   float min_grad_norm2 = 1e-12;     // Minimum gradient squared norm
   uint8_t max_total_failures = 1;   // Overall max failures to decrease error
   uint8_t max_consec_failures = 1;  // Max consecutive failures to decrease error
@@ -212,13 +212,13 @@ inline auto GN(ParametersType &X, ResidualsFunc &&acc, const Options &options = 
       if (options.log_x) {
         options.oss
             << TINYOPT_FORMAT(
-                   "✅ #{}: X:{} |δX|:{:.2e} ⎡σ⎤:{:.4f} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
+                   "✅ #{}: X:[{}] |δX|:{:.2e} ⎡σ⎤:{:.4f} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
                    out.num_iters, ptrait::toString(X), sqrt(dX_norm2), sqrt(InvCov(JtJ).maxCoeff()),
                    err, nerr, derr, Jt_res_norm2)
             << std::endl;
       } else {
-        options.oss << TINYOPT_FORMAT("✅ #{}: |δX|:{:.2e}  ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
-                                      out.num_iters, std::sqrt(dX_norm2), err, nerr, derr,
+        options.oss << TINYOPT_FORMAT("✅ #{}: |δX|:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
+                                      out.num_iters, sqrt(dX_norm2), err, nerr, derr,
                                       Jt_res_norm2)
                     << std::endl;
       }
@@ -226,13 +226,13 @@ inline auto GN(ParametersType &X, ResidualsFunc &&acc, const Options &options = 
       out.successes.emplace_back(false);
       if (options.log_x) {
         options.oss << TINYOPT_FORMAT(
-                           "❌ #{}: X:{} |δX|:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
+                           "❌ #{}: X:[{}] |δX|:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
                            out.num_iters, ptrait::toString(X), sqrt(dX_norm2), err, nerr, derr,
                            Jt_res_norm2)
                     << std::endl;
       } else {
         options.oss << TINYOPT_FORMAT("❌ #{}: |δX|:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
-                                      out.num_iters, std::sqrt(dX_norm2), err, nerr, derr,
+                                      out.num_iters, sqrt(dX_norm2), err, nerr, derr,
                                       Jt_res_norm2)
                     << std::endl;
       }

--- a/include/tinyopt/jet.h
+++ b/include/tinyopt/jet.h
@@ -18,6 +18,83 @@
 
 namespace tinyopt {
 
-template <typename T, int N> using Jet = ceres::Jet<T, N>;
+/// The Automatix differentiation Jet struct
+template <typename T, int N>
+using Jet = ceres::Jet<T, N>;
 
-} // namespace tinyopt
+// Traits
+
+namespace traits {
+
+// Check whether a type 'T' or '&T' is a Jet type
+template <typename T>
+struct is_jet_type {
+  static constexpr bool value = false;
+};
+
+template <typename T, int N>
+struct is_jet_type<Jet<T, N>> {
+  static constexpr bool value = true;
+};
+
+template <typename T>
+inline constexpr bool is_jet_type_v = is_jet_type<T>::value;
+
+// Check whether a type 'T' or '&T' is a Jet type
+template <typename T>
+struct jet_details {
+  using Scalar = double;
+  static constexpr int Dims = 0;
+};
+
+template <typename T, int N>
+struct jet_details<Jet<T, N>> {
+  using Scalar = T;
+  static constexpr int Dims = N;
+};
+
+}  // namespace traits
+
+/// Statically cast a type `T` to another one `T2`.
+/// If `T2` is a Jet, we make sure the Jet.v is allocated to the total number of dimensions
+template <typename T2, typename T>
+inline auto StaticCast(const T &v, int total_dims) {
+  using namespace traits;
+
+  if constexpr (std::is_base_of_v<Eigen::MatrixBase<T>, T>) {
+    auto o = v.template cast<T2>().eval();
+    // Ceres'Jet does not support dynamic out of the box,so here we're setting jet.v size and
+    // initialize with zeros
+    if constexpr (is_jet_type_v<T2> && jet_details<T2>::Dims == Eigen::Dynamic) {
+      for (int c = 0; c < v.cols(); ++c) {
+        for (int r = 0; r < v.rows(); ++r) {
+          o(r, c).v = Eigen::Vector<typename jet_details<T2>::Scalar, Eigen::Dynamic>::Zero(total_dims);
+        }
+      }
+    }
+    return o;
+  } else {
+    T2 o = static_cast<T2>(v);
+    // Ceres'Jet does not support dynamic out of the box,so here we're setting jet.v size and
+    // initialize with zeros
+    if constexpr (is_jet_type_v<T2> && jet_details<T2>::Dims == Eigen::Dynamic) {
+      o.v = Eigen::Vector<typename jet_details<T2>::Scalar, Eigen::Dynamic>::Zero(total_dims);
+    }
+    return o;
+  }
+}
+
+/// Dynamically cast a type `T` to another one `T2`.
+/// The method is disabled for Jet with dynamic size as the dimensions are missing.
+template <typename T2, typename T,
+          typename = std::enable_if_t<!tinyopt::traits::is_jet_type_v<T2> ||
+                                      tinyopt::traits::jet_details<T2>::Dims != Eigen::Dynamic>>
+inline auto StaticCast(const T &v) {
+  if constexpr (std::is_base_of_v<Eigen::MatrixBase<T>, T>) {
+    return v.template cast<T2>().eval();
+  } else {
+    return static_cast<T2>(v);
+  }
+}
+
+}  // namespace tinyopt

--- a/include/tinyopt/lm.h
+++ b/include/tinyopt/lm.h
@@ -168,7 +168,7 @@ inline auto LM(ParametersType &X, ResidualsFunc &&acc, const Options &options = 
       out.num_consec_failures = 0;
       if (options.log_x) {
         options.oss << TINYOPT_FORMAT(
-                           "✅ #{}: X:{} |δX|:{:.2e} λ:{:.2e} ⎡σ⎤:{:.4f} "
+                           "✅ #{}: X:[{}] |δX|:{:.2e} λ:{:.2e} ⎡σ⎤:{:.4f} "
                            "ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
                            out.num_iters, ptrait::toString(X), sqrt(dX_norm2), lambda,
                            sqrt(InvCov(JtJ).maxCoeff()), err, nerr, derr, Jt_res_norm2)
@@ -176,7 +176,7 @@ inline auto LM(ParametersType &X, ResidualsFunc &&acc, const Options &options = 
       } else {
         options.oss << TINYOPT_FORMAT(
                            "✅ #{}: |δX|:{:.2e} λ:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
-                           out.num_iters, std::sqrt(dX_norm2), lambda, err, nerr, derr,
+                           out.num_iters, sqrt(dX_norm2), lambda, err, nerr, derr,
                            Jt_res_norm2)
                     << std::endl;
       }
@@ -185,14 +185,14 @@ inline auto LM(ParametersType &X, ResidualsFunc &&acc, const Options &options = 
       out.successes.emplace_back(false);
       if (options.log_x) {
         options.oss << TINYOPT_FORMAT(
-                           "❌ #{}: X:{} |δX|:{:.2e} λ:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
+                           "❌ #{}: X:[{}] |δX|:{:.2e} λ:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
                            out.num_iters, ptrait::toString(X), sqrt(dX_norm2), lambda, err, nerr,
                            derr, Jt_res_norm2)
                     << std::endl;
       } else {
         options.oss << TINYOPT_FORMAT(
                            "❌ #{}: |δX|:{:.2e} λ:{:.2e} ε²:{:.5f} n:{} dε²:{:.3e} ∇ε²:{:.3e}",
-                           out.num_iters, std::sqrt(dX_norm2), lambda, err, nerr, derr,
+                           out.num_iters, sqrt(dX_norm2), lambda, err, nerr, derr,
                            Jt_res_norm2)
                     << std::endl;
       }

--- a/include/tinyopt/lm.h
+++ b/include/tinyopt/lm.h
@@ -41,20 +41,21 @@ using Output = tinyopt::gn::Output<JtJ_t>;
  *
  ***/
 template <typename ParametersType, typename ResidualsFunc>
-inline auto LM(ParametersType &X, ResidualsFunc &acc, const Options &options = Options{}) {
+inline auto LM(ParametersType &X, ResidualsFunc &&acc, const Options &options = Options{}) {
   using std::sqrt;
   using ptrait = traits::params_trait<ParametersType>;
 
   using Scalar = ptrait::Scalar;
   constexpr int Size = ptrait::Dims;
 
+  int size = Size; // Dynamic size
+  if constexpr (Size == Eigen::Dynamic) size = ptrait::dims(X);
+
   using JtJ_t = Matrix<Scalar, Size, Size>;
   using OutputType = Output<JtJ_t>;
   bool already_rolled_true = true;
-  const int size = ptrait::dims(X);  // System size (dynamic)
   const uint8_t max_tries =
       options.max_consec_failures > 0 ? std::max<uint8_t>(1, options.max_total_failures) : 255;
-  Matrix<Scalar, Size, 1> Jt_res(size, 1);
   auto X_last_good = X;
   double lambda = options.damping_init;
   OutputType out;
@@ -63,17 +64,20 @@ inline auto LM(ParametersType &X, ResidualsFunc &acc, const Options &options = O
   out.successes.emplace_back(out.num_iters + 2);
   if (options.export_JtJ) out.last_JtJ = JtJ_t::Zero(size, size);
   JtJ_t JtJ(size, size);
-  Matrix<Scalar, Size, 1> dX;
+  Matrix<Scalar, Size, 1> Jt_res(size, 1);
+  Matrix<Scalar, Size, 1> dX(size, 1);
   for (; out.num_iters < options.num_iters + 1 /*+1 to potentially roll-back*/; ++out.num_iters) {
     JtJ.setZero();
-    Jt_res.setZero();
+    Jt_res.setZero();;
     const auto &output = acc(X, JtJ, Jt_res);
     double err;  // accumulated error (for monotony check and logging)
     int nerr;    // number of residuals (optional, for logging)
-    if constexpr (std::is_scalar_v<std::remove_reference_t<decltype(output)>>) {
+
+    using ResOutputType = std::remove_reference_t<decltype(output)>;
+    if constexpr (std::is_scalar_v<ResOutputType>) {
       err = output;
       nerr = 1;
-    } else {
+    } else { // output must be a pair/tuple
       err = std::get<0>(output);
       nerr = std::get<1>(output);
     }
@@ -234,9 +238,9 @@ inline auto LM(ParametersType &X, ResidualsFunc &acc, const Options &options = O
  *
  ***/
 template <typename ParametersType, typename ResidualsFunc>
-inline auto Optimize(ParametersType &x, ResidualsFunc &func, const Options &options = Options{}) {
+inline auto Optimize(ParametersType &x, ResidualsFunc &&func, const Options &options = Options{}) {
   if constexpr (std::is_invocable_v<ResidualsFunc, const ParametersType &>) {
-    const auto optimize = [](auto &x, auto &func, const auto &options) { return LM(x, func, options); };
+    const auto optimize = [](auto &x, auto &&func, const auto &options) { return LM(x, func, options); };
     return tinyopt::OptimizeJet(x, func, optimize, options);
   } else {
     return LM(x, func, options);

--- a/include/tinyopt/log.h
+++ b/include/tinyopt/log.h
@@ -15,9 +15,6 @@
 #pragma once
 
 
-#include <tinyopt/traits.h>
-
-
 #if HAS_FMT
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -34,12 +31,3 @@
 #define TINYOPT_FORMAT(str, ...) str // c++ < 2020 not well supported for now
 
 #endif
-
-namespace tinyopt {
-
-template <typename T>
-std::string toString(const T& v) {
-  return traits::params_trait<T>::toString(v);
-}
-
-} // namespace tinyopt

--- a/include/tinyopt/opt_jet.h
+++ b/include/tinyopt/opt_jet.h
@@ -14,94 +14,114 @@
 
 #pragma once
 
-#include <tinyopt/jet.h>    // Import Ceres'Jet
+#include <Eigen/src/Core/Matrix.h>
+#include <Eigen/src/Core/util/Constants.h>
+#include <tinyopt/jet.h>  // Import Ceres'Jet
 #include <tinyopt/traits.h>
 
 namespace tinyopt {
 
-template <typename ParametersType, typename ResidualsFunc, typename OptimizeFunc, typename OptionsType>
-inline auto OptimizeJet(ParametersType &X, ResidualsFunc &residuals,
-                        const OptimizeFunc &optimize,
+template <typename ParametersType, typename ResidualsFunc, typename OptimizeFunc,
+          typename OptionsType>
+inline auto OptimizeJet(ParametersType &X, ResidualsFunc &&residuals, const OptimizeFunc &optimize,
                         const OptionsType &options) {
-
   using ptrait = traits::params_trait<ParametersType>;
   using Scalar = ptrait::Scalar;
   constexpr int Size = ptrait::Dims;
-  constexpr bool is_userdef_type = !std::is_floating_point_v<ParametersType>  && !traits::is_eigen_matrix_or_array_v<ParametersType>;
+  constexpr bool is_userdef_type = !std::is_floating_point_v<ParametersType> &&
+                                   !traits::is_eigen_matrix_or_array_v<ParametersType>;
 
-  const int size = ptrait::dims(X);
+  int size = Size;
+  if constexpr (Size == Eigen::Dynamic) size = ptrait::dims(X);
+
   // Construct the Jet
   using Jet = Jet<Scalar, Size>;
   // XJetType is either of {Jet, Vector<Jet, N> or ParametersType::cast<Jet>()}
-  using XJetType = std::conditional_t<std::is_floating_point_v<ParametersType>, Jet,
-                                      std::conditional_t<traits::is_eigen_matrix_or_array_v<ParametersType>,
-                                        Vector<Jet, Size>, decltype(ptrait::template cast<Jet>(X))>>;
+  using XJetType = std::conditional_t<
+      std::is_floating_point_v<ParametersType>, Jet,
+      std::conditional_t<traits::is_eigen_matrix_or_array_v<ParametersType>,
+                         Eigen::Vector<Jet, Size>, decltype(ptrait::template cast<Jet>(X))>>;
   // DXJetType is either of {nullptr, Vector<Jet, N>}
-  using DXJetType = std::conditional_t<is_userdef_type, Vector<Jet, Size>, std::nullptr_t>;
+  using DXJetType = std::conditional_t<is_userdef_type, Eigen::Vector<Jet, Size>, std::nullptr_t>;
   XJetType x_jet;
-  DXJetType dx_jet; // only for user defined X type
+  DXJetType dx_jet;  // only for user defined X type
 
   // Copy X to Jet values
-  if constexpr (is_userdef_type) { // X is user defined object
+  if constexpr (is_userdef_type) {  // X is user defined object
     dx_jet = DXJetType::Zero(size);
     for (int i = 0; i < size; ++i) {
+      // If X size at compile time is not known, we need to set the Jet.v
+      if constexpr (Size == Eigen::Dynamic)
+        dx_jet[i].v = Eigen::Vector<Scalar, Eigen::Dynamic>::Zero(size);
       dx_jet[i].v[i] = 1;
     }
     // dx_jet is constant
-  } else if constexpr (std::is_floating_point_v<ParametersType>) { // X is scalar
+  } else if constexpr (std::is_floating_point_v<ParametersType>) {  // X is scalar
     x_jet = XJetType(size);
     x_jet.v[0] = 1;
-  } else { // X is a Vector
-    x_jet = XJetType(size);
+  } else {  // X is a Vector or Matrix
+    x_jet = XJetType(size, 1);
     for (int i = 0; i < size; ++i) {
+      // If X size at compile time is not known, we need to set the Jet.v
+      if constexpr (Size == Eigen::Dynamic)
+        x_jet[i].v = Eigen::Vector<Scalar, Eigen::Dynamic>::Zero(size);
       x_jet[i].v[i] = 1;
     }
   }
 
   auto acc = [&](const auto &x, auto &JtJ, auto &Jt_res) {
-
     // Update jet with latest 'x' values
-    if constexpr (is_userdef_type) { // X is user defined object
-      x_jet = ptrait::template cast<Jet>(X); // Cast X to a Jet type
+    if constexpr (is_userdef_type) {          // X is user defined object
+      x_jet = ptrait::template cast<Jet>(X);  // Cast X to a Jet type
       using ptrait_jet = traits::params_trait<XJetType>;
       ptrait_jet::pluseq(x_jet, dx_jet);
-    } else if constexpr (std::is_floating_point_v<ParametersType>) { // X is scalar
+    } else if constexpr (std::is_floating_point_v<ParametersType>) {  // X is scalar
       x_jet.a = x;
-    } else { // X is a Vector
-      for (int i = 0; i < size; ++i) {
-        x_jet[i].a = x[i];
+    } else {  // X is a Vector or Matrix
+      for (int c = 0; c < x.cols(); ++c) {
+        for (int r = 0; r < x.rows(); ++r) {
+          x_jet[r * x.cols() + c].a = x(r, c);
+        }
       }
     }
 
     // Retrieve the residuals
     const auto res = residuals(x_jet);
-    using ResType =
-        typename std::remove_const_t<std::remove_reference_t<decltype(res)>>;
+    using ResType = typename std::remove_const_t<std::remove_reference_t<decltype(res)>>;
 
-    if constexpr (!traits::is_eigen_matrix_or_array_v<ResType> &&
-                  std::is_floating_point_v<ParametersType>) {
+    // Make sure the return type is either a Jet or Eigen::Matrix/Array<Jet>
+    static_assert(traits::is_jet_type_v<ResType> ||
+                  (traits::is_eigen_matrix_or_array_v<ResType> &&
+                   traits::is_jet_type_v<typename ResType::Scalar>));
+
+    if constexpr (!traits::is_eigen_matrix_or_array_v<ResType>) {  // One residual
       // Update JtJ and Jt*err
       const auto &J = res.v;
-      JtJ(0, 0) = J[0] * J[0];
-      Jt_res[0] = J[0] * res.a; // gradient
+      if constexpr (std::is_floating_point_v<ParametersType>) {
+        JtJ(0, 0) = J[0] * J[0];
+        Jt_res[0] = J[0] * res.a;
+      } else {
+        JtJ = J * J.transpose();
+        Jt_res = J.transpose() * res.a;
+      }
       // Return both the squared error and the number of residuals
       return std::make_pair(res.a * res.a, 1);
-    } else { // Extract jacobian (TODO speed this up)
+    } else {  // Extract jacobian (TODO speed this up)
       constexpr int ResSize = traits::params_trait<ResType>::Dims;
-      int res_size = ResSize; // System size (dynamic)
-      if constexpr (ResSize != 1 && !std::is_floating_point_v<
-                                        std::remove_reference_t<decltype(res)>>)
+      int res_size = ResSize;  // System size (dynamic)
+      if constexpr (ResSize != 1 &&
+                    !std::is_floating_point_v<std::remove_reference_t<decltype(res)>>)
         res_size = res.size();
 
       // TODO avoid this copy
-      Matrix<Scalar, ResSize, Size> J(res_size, size);
+      Eigen::Matrix<Scalar, ResSize, Size> J(res_size, size);
       for (int i = 0; i < res_size; ++i) {
         if constexpr (traits::is_eigen_matrix_or_array_v<ResType>)
           J.row(i) = res[i].v;
         else
           J.row(i) = res.v;
       }
-      Vector<Scalar, ResSize> res_f(res.rows());
+      Eigen::Vector<Scalar, ResSize> res_f(res.rows());
       for (int i = 0; i < res.rows(); ++i) {
         if constexpr (traits::is_eigen_matrix_or_array_v<ResType>)
           res_f[i] = res[i].a;
@@ -119,4 +139,4 @@ inline auto OptimizeJet(ParametersType &X, ResidualsFunc &residuals,
   return optimize(X, acc, options);
 }
 
-} // namespace tinyopt
+}  // namespace tinyopt

--- a/include/tinyopt/traits.h
+++ b/include/tinyopt/traits.h
@@ -18,8 +18,10 @@
 #include <string>
 #include <type_traits>
 
-#include <Eigen/src/Core/ArrayBase.h>
-#include <Eigen/src/Core/MatrixBase.h>
+#include <Eigen/Core>
+
+#include <tinyopt/log.h>
+#include <tinyopt/jet.h>
 
 namespace tinyopt::traits {
 
@@ -31,21 +33,21 @@ inline constexpr bool is_nullptr_type_v = is_nullptr_type<T>::value;
 
 // Trait to check if a type is an Eigen matrix
 template <typename T>
-struct is_eigen_matrix_or_array
-    : std::disjunction<std::is_base_of<Eigen::MatrixBase<T>, T>,
-                       std::is_base_of<Eigen::ArrayBase<T>, T>> {};
+struct is_eigen_matrix_or_array : std::disjunction<std::is_base_of<Eigen::MatrixBase<T>, T>,
+                                                   std::is_base_of<Eigen::ArrayBase<T>, T>> {};
 
 template <typename T>
-constexpr int is_eigen_matrix_or_array_v = is_eigen_matrix_or_array<T>::value;
+constexpr bool is_eigen_matrix_or_array_v = is_eigen_matrix_or_array<T>::value;
 
 // Default parameters trait
 
-template <typename T, typename = void> struct params_trait {
-  using Scalar = typename T::Scalar; // The scalar type
-  static constexpr int Dims = T::Dims; // Compile-time parameters dimensions
+template <typename T, typename = void>
+struct params_trait {
+  using Scalar = typename T::Scalar;    // The scalar type
+  static constexpr int Dims = T::Dims;  // Compile-time parameters dimensions
 
   // Execution-time parameters dimensions
-  static int dims(const T &v) { return Dims == Eigen::Dynamic ? v.dims() : Dims;}
+  static int dims(const T& v) { return Dims == Eigen::Dynamic ? v.dims() : Dims; }
 
   // Conversion to string
   static std::string toString(const T& v) {
@@ -56,49 +58,43 @@ template <typename T, typename = void> struct params_trait {
 
   // Cast to a new type, only needed when using automatic differentiation
   template <typename T2>
-  static auto cast(const T &v) {
+  static auto cast(const T& v) {
     return v.template cast<T2>();
   }
 
   // Define update / manifold
-  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
-    v += delta;
-  }
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) { v += delta; }
 };
 
 // Trait specialization for scalar (float, double)
 template <typename T>
 struct params_trait<T, std::enable_if_t<std::is_scalar_v<T>>> {
-  using Scalar = T; // The scalar type
-  static constexpr int Dims = 1; // Compile-time parameters dimensions
+  using Scalar = T;               // The scalar type
+  static constexpr int Dims = 1;  // Compile-time parameters dimensions
   // Execution-time parameters dimensions
-  static constexpr int dims(const T &) { return 1;}
+  static constexpr int dims(const T&) { return 1; }
   // Conversion to string
-  static std::string toString(const T& v) {
-    return std::to_string(v);
-  }
+  static std::string toString(const T& v) { return std::to_string(v); }
   // Cast to a new type, only needed when using automatic differentiation
   template <typename T2>
-  static T2 cast(const T &v) {
+  static T2 cast(const T& v) {
     return T2(v);
   }
   // Define update / manifold
-  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
-    v += delta[0];
-  }
-  static void pluseq(T& v, const Scalar& delta) {
-    v += delta;
-  }
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) { v += delta[0]; }
+  static void pluseq(T& v, const Scalar& delta) { v += delta; }
 };
 
 // Trait specialization for Eigen::MatrixBase
 template <typename T>
-struct params_trait<
-    T, std::enable_if_t<std::is_base_of_v<Eigen::MatrixBase<T>, T>>> {
-  using Scalar = typename T::Scalar; // The scalar type
-  static constexpr int Dims = T::RowsAtCompileTime; // Compile-time parameters dimensions
+struct params_trait<T, std::enable_if_t<is_eigen_matrix_or_array_v<T>>> {
+  using Scalar = typename T::Scalar;  // The scalar type
+  static constexpr int Dims =
+      (T::RowsAtCompileTime == Eigen::Dynamic || T::ColsAtCompileTime == Eigen::Dynamic)
+          ? Eigen::Dynamic
+          : T::RowsAtCompileTime * T::ColsAtCompileTime;  // Compile-time parameters dimensions
   // Execution-time parameters dimensions
-  static int dims(const T &m) { return m.size();}
+  static int dims(const T& m) { return m.size(); }
   // Conversion to string
   static std::string toString(const T& m) {
     std::stringstream ss;
@@ -110,13 +106,99 @@ struct params_trait<
   }
   // Cast to a new type, only needed when using automatic differentiation
   template <typename T2>
-  static auto cast(const T &v) {
-    return v.template cast<T2>();
+  static auto cast(const T& v) {
+    if constexpr (Dims == Eigen::Dynamic) {
+      return StaticCast<T2>(v, v.size());
+    } else {
+      return v.template cast<T2>().eval();
+    }
   }
   // Define update / manifold
   static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
-    v += delta;
+    if constexpr (Dims == Eigen::Dynamic) assert(delta.rows() == (int)v.size());
+    if constexpr (T::ColsAtCompileTime == 1)
+      v += delta;
+    else if (v.cols() == 1)
+      v += delta;
+    else
+      v += delta.reshaped(v.rows(), v.cols());
   }
 };
 
-} // namespace tinyopt::traits
+// Trait specialization for std vector
+template <typename _Scalar>
+struct params_trait<std::vector<_Scalar>> {
+  using T = std::vector<_Scalar>;
+  using Scalar = _Scalar;                      // The scalar type
+  static constexpr int Dims = Eigen::Dynamic;  // Compile-time parameters dimensions
+  // Execution-time parameters dimensions
+  static int dims(const T& v) { return v.size(); }
+  // Conversion to string
+  static std::string toString(const T& v) {
+    std::stringstream ss;
+#if __cplusplus >= 202302L
+    ss << TINYOPT_FORMAT("{}", v);
+#else
+    for (std::size_t i = 0; i < v.size(); ++i) {
+      ss << v[i];
+      if (i+1 < v.size()) ss << " ";
+    }
+#endif
+    return ss.str();
+  }
+  // Cast to a new type, only needed when using automatic differentiation
+  template <typename T2>
+  static auto cast(const T& v) {
+    std::vector<T2> o(v.size());
+    for (std::size_t i = 0; i < v.size(); ++i) o[i] = StaticCast<T2>(v[i], v.size());
+    return o;
+  }
+  // Define update / manifold
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
+    if constexpr (Dims == Eigen::Dynamic) assert(delta.rows() == (int)v.size());
+    for (std::size_t i = 0; i < v.size(); ++i) v[i] += delta[i];
+  }
+};
+
+// Trait specialization for std::array
+template <typename _Scalar, std::size_t N>
+struct params_trait<std::array<_Scalar, N>> {
+  using T = std::array<_Scalar, N>;
+  using Scalar = _Scalar;         // The scalar type
+  static constexpr int Dims = N;  // Compile-time parameters dimensions
+  // Conversion to string
+  static std::string toString(const T& v) {
+    std::stringstream ss;
+#if __cplusplus >= 202302L
+    ss << TINYOPT_FORMAT("{}", v);
+#else
+    for (std::size_t i = 0; i < N; ++i) {
+      ss << v[i];
+      if (i+1 < v.size()) ss << " ";
+    }
+#endif
+    return ss.str();
+  }
+  // Cast to a new type, only needed when using automatic differentiation
+  template <typename T2>
+  static auto cast(const T& v) {
+    std::array<T2, N> o;
+    for (std::size_t i = 0; i < N; ++i) o[i] = static_cast<T2>(v[i]);
+    return o;
+  }
+  // Define update / manifold
+  static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
+    for (std::size_t i = 0; i < N; ++i) v[i] += delta[i];
+  }
+};
+
+}  // namespace tinyopt::traits
+
+namespace tinyopt {
+
+  template <typename T>
+  std::string toString(const T& v) {
+    return traits::params_trait<T>::toString(v);
+  }
+
+} // namespace tinyopt

--- a/include/tinyopt/traits.h
+++ b/include/tinyopt/traits.h
@@ -101,7 +101,7 @@ struct params_trait<T, std::enable_if_t<is_eigen_matrix_or_array_v<T>>> {
     if (m.cols() == 1)
       ss << m.transpose();
     else
-      ss << m;
+      ss << m.reshaped().transpose();
     return ss.str();
   }
   // Cast to a new type, only needed when using automatic differentiation
@@ -117,8 +117,6 @@ struct params_trait<T, std::enable_if_t<is_eigen_matrix_or_array_v<T>>> {
   static void pluseq(T& v, const Eigen::Vector<Scalar, Dims>& delta) {
     if constexpr (Dims == Eigen::Dynamic) assert(delta.rows() == (int)v.size());
     if constexpr (T::ColsAtCompileTime == 1)
-      v += delta;
-    else if (v.cols() == 1)
       v += delta;
     else
       v += delta.reshaped(v.rows(), v.cols());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+add_executable(tinyopt_test_types types.cpp)
+add_test(NAME tinyopt_test_types COMMAND tinyopt_test_types)
+target_link_libraries(tinyopt_test_types PRIVATE ${THIRDPARTY_TEST_LIBS} tinyopt)
+
 add_executable(tinyopt_test_sqrt2 sqrt2.cpp)
 add_test(NAME tinyopt_test_sqrt2 COMMAND tinyopt_test_sqrt2)
 target_link_libraries(tinyopt_test_sqrt2 PRIVATE ${THIRDPARTY_TEST_LIBS} tinyopt)

--- a/tests/circle.cpp
+++ b/tests/circle.cpp
@@ -61,9 +61,9 @@ void TestFitCircle() {
   const auto &out = Optimize(x, loss, options);
 
   REQUIRE(out.Succeeded());
-  REQUIRE(x.x() == Approx(center.x()).epsilon(1e-5));
-  REQUIRE(x.y() == Approx(center.y()).epsilon(1e-5));
-  REQUIRE(x.z() == Approx(radius).epsilon(1e-5));
+  REQUIRE(x.x() == Approx(center.x()).margin(1e-5));
+  REQUIRE(x.y() == Approx(center.y()).margin(1e-5));
+  REQUIRE(x.z() == Approx(radius).margin(1e-5));
 }
 
 TEST_CASE("tinyopt_fitcircle") {

--- a/tests/sqrt2.cpp
+++ b/tests/sqrt2.cpp
@@ -47,7 +47,7 @@ void TestSqrt2() {
 
   REQUIRE(out.Succeeded());
   REQUIRE(out.Converged());
-  REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
 }
 
 void TestSqrt2Jet() {
@@ -61,7 +61,7 @@ void TestSqrt2Jet() {
 
   REQUIRE(out.Succeeded());
   REQUIRE(out.Converged());
-  REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
 }
 
 void TestSqrt2Jet2() {
@@ -80,7 +80,7 @@ void TestSqrt2Jet2() {
 
   REQUIRE(out.Succeeded());
   REQUIRE(out.Converged());
-  REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
 }
 
 void TestSqrt2Jet2GN() {
@@ -94,7 +94,7 @@ void TestSqrt2Jet2GN() {
 
   REQUIRE(out.Succeeded());
   REQUIRE(out.Converged());
-  REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
 }
 
 TEST_CASE("tinyopt_sqrt2") {

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <cmath>
+#include "tinyopt/jet.h"
+#include "tinyopt/lm.h"
 
 #if CATCH2_VERSION == 2
 #include <catch2/catch.hpp>
@@ -31,12 +33,12 @@ void TestScalars() {
   {
     double x = 1;
     Optimize(x, [](const auto &x) { return x * x - 2.0; });
-    REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+    REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
   }
   {
     float x = 1;
     Optimize(x, [](const auto &x) { return x * x - 2.0f; });
-    REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+    REQUIRE(x == Approx(std::sqrt(2.0)).margin(1e-5));
   }
 }
 
@@ -44,12 +46,12 @@ void TestStl() {
   {
     std::array<double, 3> x{{1, 2, 3}};
     Optimize(x, [](const auto &x) { return x[0] + x[1] + x[2] - 10.0; });
-    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).epsilon(1e-5));
+    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).margin(1e-5));
   }
   {
     std::vector<float> x{{1, 2, 3}};
     Optimize(x, [](const auto &x) { return x[0] + x[1] + x[2] - 10.0f; });
-    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).epsilon(1e-5));
+    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).margin(1e-5));
   }
 }
 
@@ -58,38 +60,55 @@ void TestEigenVector() {
     using Vec = Eigen::Vector<double, 2>;
     Vec x = Vec::Ones();
     Optimize(x, [](const auto &x) { return (x - Vec::Constant(2.0)).eval(); });
-    // TODO fix me: REQUIRE((x.array() - 2.0).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
+    REQUIRE((x.array() - 2.0).cwiseAbs().sum() == Approx(0.0).margin(1e-5));
   }
   {
     using Vec = Eigen::Vector<double, 2>;
     Vec x = Vec::Ones();
     Optimize(x, [](const auto &x) { return x[0] + x[1] - 10.0; });
-    REQUIRE(x[0] + x[1] == Approx(10.0).epsilon(1e-5));
+    REQUIRE(x[0] + x[1] == Approx(10.0).margin(1e-5));
   }
   {
     using Vec = Eigen::Vector<float, Eigen::Dynamic>;
     Vec x = Vec::Ones(3);
     Optimize(x, [](const auto &x) { return (x.array() - 2.0f).eval(); });
-    REQUIRE((x.array() - 2.0f).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
+    REQUIRE((x.array() - 2.0f).cwiseAbs().sum() == Approx(0.0).margin(1e-5));
   }
 }
 
 void TestEigenMatrix() {
-  /*{
+  {
     using Mat = Eigen::Matrix<float, 2, 3>;
-    Mat x = Mat::Random(), y = Mat::Random();
+    Mat x = Mat::Random(), y = Mat::Random() * 10;
     Optimize(x, [&y](const auto &x) {
       using T = std::remove_reference_t<decltype(x)>::Scalar;
-      //return (x - y.template cast<T>()).reshaped().eval(); // Vector
-      return Eigen::VectorX<T>((x - y.template cast<T>()).reshaped().eval()); // Vector
+      return (x - StaticCast<T>(y)).reshaped().eval(); // Vector
     });
-    REQUIRE((x.array() - y.array()).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
-  }*/
+    REQUIRE((x.array() - y.array()).cwiseAbs().sum() == Approx(0.0).margin(1e-5));
+  }
+  {
+    using Mat = Eigen::Matrix<double, 3, 2>;
+    Mat x = Mat::Random(), y = Mat::Random() * 10;
+    Optimize(x, [&y](const auto &x) {
+      using T = std::remove_reference_t<decltype(x)>::Scalar;
+      return (x - StaticCast<T>(y)).eval(); // Matrix
+    });
+    REQUIRE((x.array() - y.array()).cwiseAbs().sum() == Approx(0.0).margin(1e-5));
+  }
+  {
+    using Mat = Eigen::Matrix<double, 3, Eigen::Dynamic>;
+    Mat x = Mat::Random(3, 2), y = Mat::Random(3, 2) * 10;
+    const auto &out = Optimize(x, [&y](const auto &x) {
+      using T = std::remove_reference_t<decltype(x)>::Scalar;
+      return (x - StaticCast<T>(y, 2*3)).eval(); // Matrix
+    });
+    REQUIRE((x.array() - y.array()).cwiseAbs().sum() == Approx(0.0).margin(1e-5));
+  }
 }
 
 TEST_CASE("tinyopt_types") {
   TestScalars();
   TestStl();
   TestEigenVector();
-  //TestEigenMatrix();
+  TestEigenMatrix();
 }

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) 2025 Julien Michot. All Rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+
+#if CATCH2_VERSION == 2
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include "tinyopt/tinyopt.h"
+
+using namespace tinyopt;
+
+using Catch::Approx;
+
+void TestScalars() {
+  {
+    double x = 1;
+    Optimize(x, [](const auto &x) { return x * x - 2.0; });
+    REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  }
+  {
+    float x = 1;
+    Optimize(x, [](const auto &x) { return x * x - 2.0f; });
+    REQUIRE(x == Approx(std::sqrt(2.0)).epsilon(1e-5));
+  }
+}
+
+void TestStl() {
+  {
+    std::array<double, 3> x{{1, 2, 3}};
+    Optimize(x, [](const auto &x) { return x[0] + x[1] + x[2] - 10.0; });
+    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).epsilon(1e-5));
+  }
+  {
+    std::vector<float> x{{1, 2, 3}};
+    Optimize(x, [](const auto &x) { return x[0] + x[1] + x[2] - 10.0f; });
+    REQUIRE((x[0] + x[1] + x[2]) == Approx(10.0).epsilon(1e-5));
+  }
+}
+
+void TestEigenVector() {
+  {
+    using Vec = Eigen::Vector<double, 2>;
+    Vec x = Vec::Ones();
+    Optimize(x, [](const auto &x) { return (x - Vec::Constant(2.0)).eval(); });
+    // TODO fix me: REQUIRE((x.array() - 2.0).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
+  }
+  {
+    using Vec = Eigen::Vector<double, 2>;
+    Vec x = Vec::Ones();
+    Optimize(x, [](const auto &x) { return x[0] + x[1] - 10.0; });
+    REQUIRE(x[0] + x[1] == Approx(10.0).epsilon(1e-5));
+  }
+  {
+    using Vec = Eigen::Vector<float, Eigen::Dynamic>;
+    Vec x = Vec::Ones(3);
+    Optimize(x, [](const auto &x) { return (x.array() - 2.0f).eval(); });
+    REQUIRE((x.array() - 2.0f).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
+  }
+}
+
+void TestEigenMatrix() {
+  /*{
+    using Mat = Eigen::Matrix<float, 2, 3>;
+    Mat x = Mat::Random(), y = Mat::Random();
+    Optimize(x, [&y](const auto &x) {
+      using T = std::remove_reference_t<decltype(x)>::Scalar;
+      //return (x - y.template cast<T>()).reshaped().eval(); // Vector
+      return Eigen::VectorX<T>((x - y.template cast<T>()).reshaped().eval()); // Vector
+    });
+    REQUIRE((x.array() - y.array()).cwiseAbs().sum() == Approx(0.0).epsilon(1e-5));
+  }*/
+}
+
+TEST_CASE("tinyopt_types") {
+  TestScalars();
+  TestStl();
+  TestEigenVector();
+  //TestEigenMatrix();
+}

--- a/tests/userdef_params.cpp
+++ b/tests/userdef_params.cpp
@@ -114,10 +114,10 @@ void TestUserDefinedParameters() {
             << ", loss:" << loss(rectangle, null, null) << "\n";
 
   REQUIRE(out.Succeeded());
-  REQUIRE(rectangle.p1.x() == Approx(1).epsilon(1e-5));
-  REQUIRE(rectangle.p1.y() == Approx(2).epsilon(1e-5));
-  REQUIRE(rectangle.p2.x() == Approx(3).epsilon(1e-5));
-  REQUIRE(rectangle.p2.y() == Approx(4).epsilon(1e-5));
+  REQUIRE(rectangle.p1.x() == Approx(1).margin(1e-5));
+  REQUIRE(rectangle.p1.y() == Approx(2).margin(1e-5));
+  REQUIRE(rectangle.p2.x() == Approx(3).margin(1e-5));
+  REQUIRE(rectangle.p2.y() == Approx(4).margin(1e-5));
 }
 
 TEST_CASE("tinyopt_userdef_params") { TestUserDefinedParameters(); }

--- a/tests/userdef_params_jet.cpp
+++ b/tests/userdef_params_jet.cpp
@@ -16,6 +16,7 @@
 #include <ostream>
 
 #include <Eigen/Eigen>
+#include "tinyopt/jet.h"
 
 #if CATCH2_VERSION == 2
 #include <catch2/catch.hpp>
@@ -29,10 +30,10 @@
 using Catch::Approx;
 
 // Example of a rectangle
-template <typename T> // Template is only needed if you need automatic
-                      // differentiation
+template <typename T>  // Template is only needed if you need automatic
+                       // differentiation
 struct Rectangle {
-  using Vec2 = Eigen::Vector<T, 2>; // Just for convenience
+  using Vec2 = Eigen::Vector<T, 2>;  // Just for convenience
   Rectangle() : p1(Vec2::Zero()), p2(Vec2::Zero()) {}
   explicit Rectangle(const Vec2 &_p1, const Vec2 &_p2) : p1(_p1), p2(_p2) {}
 
@@ -47,20 +48,20 @@ struct Rectangle {
   // Returns the center of the rectangle
   Vec2 center() const { return T(0.5) * (p1 + p2); }
 
-  Vec2 p1, p2; // top left and bottom right positions
+  Eigen::Vector<T, Eigen::Dynamic> p1;  // top left positions (with a dynamic vector to test this)
+  Vec2 p2;                              // bottom right positions
 };
 
 namespace tinyopt::traits {
 
 // Here we define the parametrization of a Rectangle, this is needed to be able
 // to Optimize one.
-template <typename T> struct params_trait<Rectangle<T>> {
-  using Scalar = T;              // The scalar type
-  static constexpr int Dims = 4; // Compile-time parameters dimensions
-  // Execution-time parameters dimensions
-  static constexpr int dims(const Rectangle<T> &) {
-    return Dims;
-  } // same as Dims
+template <typename T>
+struct params_trait<Rectangle<T>> {
+  using Scalar = T;               // The scalar type
+  static constexpr int Dims = 4;  // Compile-time parameters dimensions
+  // Execution-time parameters dimensions (optional)
+  static constexpr int dims(const Rectangle<T> &) { return Dims; }
   // Conversion to string
   static std::string toString(const Rectangle<T> &rect) {
     std::stringstream os;
@@ -70,21 +71,22 @@ template <typename T> struct params_trait<Rectangle<T>> {
 
   // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>, only used by
   // auto differentiation
-  template <typename T2> static Rectangle<T2> cast(const Rectangle<T> &rect) {
-    return Rectangle<T2>(rect.p1.template cast<T2>(),
-                         rect.p2.template cast<T2>());
+  template <typename T2>
+  static Rectangle<T2> cast(const Rectangle<T> &rect) {
+    return Rectangle<T2>(
+      StaticCast<T2>(rect.p1, Dims), // p1 has a dynamic size so you MUST use StaticCast<>() instead of .cast<>()
+      rect.p2.template cast<T2>());
   }
 
   // Define update / manifold
-  static void pluseq(Rectangle<T> &rect,
-                     const Eigen::Vector<Scalar, Dims> &delta) {
+  static void pluseq(Rectangle<T> &rect, const Eigen::Vector<Scalar, Dims> &delta) {
     // Here I'm choosing a non trivial parametrization (delta center x, delta
     // center y, delta width, delta height) just to illustrate one can use any
     // parametrization/manifold
     rect.p1.x() += delta[0];
-    rect.p2.x() += delta[0] + delta[2]; // += dx + dw
+    rect.p2.x() += delta[0] + delta[2];  // += dx + dw
     rect.p1.y() += delta[1];
-    rect.p2.y() += delta[1] + delta[3]; // += dy + dh
+    rect.p2.y() += delta[1] + delta[3];  // += dy + dh
 
     // But you can simply do:
     // rect.p1 += delta.template head<2>();
@@ -92,7 +94,7 @@ template <typename T> struct params_trait<Rectangle<T>> {
   }
 };
 
-} // namespace tinyopt::traits
+}  // namespace tinyopt::traits
 
 using namespace tinyopt;
 
@@ -107,7 +109,7 @@ void TestUserDefinedParameters() {
     Eigen::Vector<T, 4> residuals;
     residuals[0] = rect.area() - 10.0f * 20.0f;
     residuals[1] = 100.0f * (rect.width() / max(rect.height(), T(1e-8f)) -
-                             2.0f); // the 1e-8 is to prevent division by 0
+                             2.0f);  // the 1e-8 is to prevent division by 0
     residuals.template tail<2>() = rect.center() - Eigen::Vector<T, 2>(1, 2);
     return residuals;
   };
@@ -117,8 +119,7 @@ void TestUserDefinedParameters() {
   options.damping_init = 1e-1;
   const auto &out = Optimize(rectangle, loss);
 
-  std::cout << "rect:" << "area:" << rectangle.area()
-            << ", c:" << rectangle.center().transpose()
+  std::cout << "rect:" << "area:" << rectangle.area() << ", c:" << rectangle.center().transpose()
             << ", size:" << rectangle.height() << "x" << rectangle.width()
             << ", loss:" << loss(rectangle).transpose() << "\n";
 

--- a/tests/userdef_params_jet.cpp
+++ b/tests/userdef_params_jet.cpp
@@ -124,10 +124,10 @@ void TestUserDefinedParameters() {
             << ", loss:" << loss(rectangle).transpose() << "\n";
 
   REQUIRE(out.Succeeded());
-  REQUIRE(rectangle.area() == Approx(10 * 20).epsilon(1e-5));
-  REQUIRE(rectangle.center().x() == Approx(1).epsilon(1e-5));
-  REQUIRE(rectangle.center().y() == Approx(2).epsilon(1e-5));
-  REQUIRE(rectangle.width() == Approx(2 * rectangle.height()).epsilon(1e-5));
+  REQUIRE(rectangle.area() == Approx(10 * 20).margin(1e-5));
+  REQUIRE(rectangle.center().x() == Approx(1).margin(1e-5));
+  REQUIRE(rectangle.center().y() == Approx(2).margin(1e-5));
+  REQUIRE(rectangle.width() == Approx(2 * rectangle.height()).margin(1e-5));
 }
 
 TEST_CASE("tinyopt_userdef_params") { TestUserDefinedParameters(); }


### PR DESCRIPTION
In this PR, I'm adding support for STL array & vector parameters type as well as returning a Matrix.
Usage example:
```cpp
std::array<float, 3> x;
Optimize (x, loss, ...);
```
or 
```cpp
Eigen::Matrix<float, 3, 2> x;
Optimize (x, loss, ...);
```

I'm also fixing the dynamic sized parameters.
