### PR TITLE
Add Eigen include before including lie++

### DIFF
--- a/include/tinyopt/3rdparty/traits/lieplusplus.h
+++ b/include/tinyopt/3rdparty/traits/lieplusplus.h
@@ -14,8 +14,10 @@
 
 #pragma once
 
-namespace lieplusplus { // placing it in a namespace
-#include <groups/SEn3.hpp>  // for now we define only SE3 and SO3
+#include <Eigen/Dense> // Must be before any include groups/* due to lieplusplus namespace
+
+namespace lieplusplus { // Place all lie++ under the lieplusplus namespace
+#include <groups/SEn3.hpp>  // For now we define only SE3 and SO3
 }
 
 #include <tinyopt/traits.h>


### PR DESCRIPTION
This is due to the added namespace which makes an include to Eigen/Dense and might conflict.
Usage example
```cpp
#include <Eigen/Dense> // Must be before SEn3.hpp
namespace lieplusplus { // Place all lie++ under the lieplusplus namespace
#include <groups/SEn3.hpp>
}
using Pose = lieplusplus::group::SEn3<double, 1>;  // SE3
```