### PR TITLE
Fix/avoid empty constructor params struct

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -214,6 +214,52 @@ Optimize(rectangle, loss);
 // That's it, rectangle is now fitted to your loss
 ```
 
+### How to skip data copies?
+
+How do I create a parameters wrapper struct that uses external data sources without expensive copies?
+This way:
+
+```cpp
+
+template <typename MyPoses>
+struct ParamsWrapper {
+  static constexpr Index Dims = Dynamic;
+  ParamsWrapper() = delete;
+  ParamsWrapper(MyPoses &poses_) : poses{poses_} {}
+  ParamsWrapper(MyPoses &&poses_) : poses{poses_} {}
+
+  int dims() const { return poses2.size(); }
+
+  // Returns a copy where the scalar is converted to another type 'T2'.
+  // This is only used by auto differentiation
+  template <typename T2>
+  inline auto cast() const {
+    auto poses2 = poses.template cast<T2>(); // must be defined by MyPoses
+    using MyPoses2 = std::decay_t<decltype(poses2)>;
+    ParamsWrapper<MyPoses2> x2(std::move(poses2));
+    return std::move(x2);
+  }
+
+  // Define update / manifold
+  ParamsWrapper &operator+=(const auto &delta) {
+    poses += delta; // must be defined by MyPoses
+    return *this;
+  }
+
+  MyPoses &poses; // look Ma, no copy!
+  // And you can add more parameters here, so fun!
+  // Note: Avoid adding const data here.
+};
+
+// You can now optimize x and the poses will be updated
+MyPoses poses;
+...
+Parameters<MyPoses> x(poses);
+Optimize(x, loss);
+
+```
+Ok, there will be copies when using Auto Diff (which calls the `cast()` method), one per iteration.
+
 ### Numerical Differentiation
 Not all cost functions are the same. By default, `tinyopt` will try to use automatic differentiation
 when the function has only one parameter `x` but if your function does not allow it,

--- a/include/tinyopt/diff/optimize_autodiff.h
+++ b/include/tinyopt/diff/optimize_autodiff.h
@@ -41,15 +41,19 @@ inline auto OptimizeWithAutoDiff(X_t &X, const ResidualsFunc &residuals,
 
   // Construct the Jet
   using Jet = diff::Jet<Scalar, Dims>;
-  // XJetType is either of {Jet, Vector<Jet, N> or X_t::cast<Jet>()}
-  using XJetType = std::conditional_t<std::is_floating_point_v<X_t>, Jet,
-                                      decltype(ptrait::template cast<Jet>(X))>;
-  // DXJetType is either of {nullptr, Vector<Jet, Dims>, Matrix<Jet, Rows, Cols>}
-  using DXJetType = std::conditional_t<is_userdef_type, Vector<Jet, Dims>, std::nullptr_t>;
-  XJetType x_jet;
-  DXJetType dx_jet;  // only for user defined X type
 
-  // Copy X to Jet values
+  // Note: XJetType and DXJetType are only instantiated to avoid having to set the 'v's at each iteration
+
+  // Construct the Jet for scalar or Matrix, so {Jet, Vector<Jet, N> ot nullptr_t}
+  using XJetType = std::conditional_t<
+      std::is_floating_point_v<X_t>, Jet,
+      std::conditional_t<is_userdef_type, std::nullptr_t, decltype(ptrait::template cast<Jet>(X))>>;
+  XJetType x_jet;
+
+  // DXJetType is either of {Vector<Jet, Dims>, Matrix<Jet, Rows, Cols>, nullptr}
+  using DXJetType = std::conditional_t<is_userdef_type, Vector<Jet, Dims>, std::nullptr_t>;
+
+  DXJetType dx_jet;  // only for user defined X type
   if constexpr (is_userdef_type) {  // X is user defined object
     dx_jet = DXJetType::Zero(size);
     for (Index i = 0; i < size; ++i) {
@@ -73,24 +77,31 @@ inline auto OptimizeWithAutoDiff(X_t &X, const ResidualsFunc &residuals,
     }
   }
 
-  auto acc = [&](const auto &x, auto &grad, auto &H) {
-    constexpr bool HasGrad = !traits::is_nullptr_v<decltype(grad)>;
-    constexpr bool HasH = !traits::is_nullptr_v<decltype(H)>;
-    // Update jet with latest 'x' values
-    if constexpr (is_userdef_type) {          // X is user defined object
-      x_jet = ptrait::template cast<Jet>(X);  // Cast X to a Jet type
-      using ptrait_jet = traits::params_trait<XJetType>;
+  // Update jet with latest 'x' values, either returning the 'x_jet' or a local copy for user defined types
+  auto update_x_jet = [&](const auto &x) {
+    if constexpr (is_userdef_type) {
+      auto x_jet = ptrait::template cast<Jet>(x);  // Cast X to a Jet type // TODO reduce copy
+      using ptrait_jet = traits::params_trait<std::decay_t<decltype(x_jet)>>;
       ptrait_jet::PlusEq(x_jet, dx_jet);
+      return std::move(x_jet);
     } else if constexpr (std::is_floating_point_v<X_t>) {  // X is scalar
       x_jet.a = x;
+      return x_jet;
     } else {  // X is a Vector or Matrix
       for (int c = 0; c < x.cols(); ++c) {
         for (int r = 0; r < x.rows(); ++r) {
           x_jet(r, c).a = x(r, c);
         }
       }
+      return x_jet;
     }
+  };
 
+  auto acc = [&](const auto &x, auto &grad, auto &H) {
+    constexpr bool HasGrad = !traits::is_nullptr_v<decltype(grad)>;
+    constexpr bool HasH = !traits::is_nullptr_v<decltype(H)>;
+
+    const auto &x_jet = update_x_jet(x);
     // Retrieve the residuals
     const auto res = residuals(x_jet);
     using ResType = typename std::decay_t<decltype(res)>;

--- a/include/tinyopt/optimizers/optimizer.h
+++ b/include/tinyopt/optimizers/optimizer.h
@@ -109,23 +109,70 @@ class Optimizer {
     return resized;
   }
 
-  /// Main optimization function
-  template <typename X_t, typename AccFunc>
-  OutputType operator()(X_t &x, const AccFunc &acc, int max_iters = -1) {
+  /**
+   * @brief Performs optimization on the given parameters `x` using the provided
+   * cost or accumulation function `cost_or_acc`.
+   *
+   * This function is the primary interface for optimization within the library. It
+   * takes the variable to be optimized and a function (or functor) that
+   * calculates the objective function, its gradient, and optionally its Hessian.
+   * The optimization process attempts to find a value of `x` that minimizes the
+   * objective function.
+   *
+   * @tparam X_t The type of the parameters `x`.  This can be a scalar, a
+   * vector, or a more complex data structure (e.g., a matrix).  The type must
+   * support the necessary arithmetic operations for the chosen optimization
+   * algorithm.
+   * @tparam CostOrAccFunc The type of the cost or accumulation function `cost_or_acc`.  This can be
+   * a function pointer, a lambda expression, or a functor (an object that
+   * overloads the `operator()`).
+   *
+   * @param x The variable to be optimized.  This is passed by reference, and
+   * the function will modify `x` in place to store the optimized value.
+   * @param cost_or_acc The cost or accumulation function.  This function calculates the objective
+   * function and, optionally, its derivatives.  The `cost_or_acc` function can have
+   * one of the following signatures:
+   * - `ResidualsType(const X_t& x)`:  Only the objective function value is
+   * calculated.  In this case, the library will use automatic differentiation
+   * (if available and enabled) or numerical differentiation to estimate the
+   * gradient.
+   * - `ScalarCost(const X_t& x, GradientType grad)`:  The
+   * objective function value and its gradient are calculated.
+   * - `ScalarCost(const X_t& x, GradientType grad, HessianType H)`:
+   * The objective function value, its gradient, and its Hessian matrix
+   * are calculated.
+   * The `GradientType` and `HessianType` will be deduced from the type of `x`.
+   * They can also be nullptr_t.
+   * * ResidualsType is a scalar or Vector/Matrix of residuals (for NLLS).
+   * * ScalarCost is the total cost/error or a pair (cost, number of residuals).
+   * @param max_iters The maximum number of iterations to perform.  If this is
+   * negative (the default), the optimization algorithm will run until a
+   * convergence criterion is met.  A positive value limits the number of
+   * iterations, which can be useful for preventing infinite loops or for
+   * controlling the execution time.
+   *
+   * @note If the `cost_or_acc` function only provides the objective function value or residuals
+   * function, the library will automatically compute the gradient (and approx. Hessian) using
+   * either automatic differentiation (if available and enabled) or numerical differentiation.
+   * Automatic differentiation is generally more accurate and efficient, but numerical
+   * differentiation can be used as a fallback or when automatic differentiation is not supported.
+   */
+  template <typename X_t, typename CostOrAccFunc>
+  OutputType Optimize(X_t &x, const CostOrAccFunc &cost_or_acc, int max_iters = -1) {
     // Detect if we need to do  differentiation
-    if constexpr (std::is_invocable_v<AccFunc, const X_t &>) {
+    if constexpr (std::is_invocable_v<CostOrAccFunc, const X_t &>) {
       // Try to run AD
 #ifndef TINYOPT_DISABLE_AUTODIFF
       using Jet = diff::Jet<Scalar, Dims>;
       using XJetType =
           std::conditional_t<std::is_floating_point_v<X_t>, Jet,
                              decltype(traits::params_trait<X_t>::template cast<Jet>(x))>;
-      if constexpr (std::is_invocable_v<AccFunc, const XJetType &>) {
+      if constexpr (std::is_invocable_v<CostOrAccFunc, const XJetType &>) {
         const auto optimize = [&](auto &x, const auto &func, const auto &) {
-          return Optimize(x, func, max_iters);
+          return OptimizeInternal(x, func, max_iters);
         };
         constexpr bool kIsNLLS = SolverType::IsNLLS;
-        return tinyopt::OptimizeWithAutoDiff<kIsNLLS>(x, acc, optimize, options_);
+        return tinyopt::OptimizeWithAutoDiff<kIsNLLS>(x, cost_or_acc, optimize, options_);
       }
 #else
       if constexpr (0) {
@@ -138,11 +185,11 @@ class Optimizer {
         // TODO #pragma message("Your function cannot be auto-differentiated, using numerical
         // differentiation")
         if constexpr (SolverType::FirstOrder) {
-          auto loss = diff::CreateNumDiffFunc1(x, acc);
-          return Optimize(x, loss, max_iters);
+          auto loss = diff::CreateNumDiffFunc1(x, cost_or_acc);
+          return OptimizeInternal(x, loss, max_iters);
         } else {
-          auto loss = diff::CreateNumDiffFunc2(x, acc);
-          return Optimize(x, loss, max_iters);
+          auto loss = diff::CreateNumDiffFunc2(x, cost_or_acc);
+          return OptimizeInternal(x, loss, max_iters);
         }
       }
 #else
@@ -151,13 +198,24 @@ class Optimizer {
       }
 #endif  // TINYOPT_DISABLE_NUMDIFF
     } else {
-      return Optimize(x, acc, max_iters);
+      return OptimizeInternal(x, cost_or_acc, max_iters);
     }
   }
 
+  /**
+   * @brief Performs optimization on the given parameters `x` using the provided
+   * cost or accumulation function `cost_or_acc`.
+   * See \ref Optimize for more informations.
+   */
+  template <typename X_t, typename CostOrAccFunc>
+  OutputType operator()(X_t &x, const CostOrAccFunc &cost_or_acc, int max_iters = -1) {
+    return Optimize(x, cost_or_acc, max_iters);
+  }
+
+ protected:
   /// Main optimization loop
   template <typename X_t, typename AccFunc>
-  OutputType Optimize(X_t &x, const AccFunc &acc, int max_iters = -1) {
+  OutputType OptimizeInternal(X_t &x, const AccFunc &acc, int max_iters = -1) {
     using ptrait = traits::params_trait<X_t>;
     OutputType out;
     // Set start time
@@ -240,7 +298,6 @@ class Optimizer {
     return out;
   }
 
- protected:
   /// Run one optimization iteration, return the estimated next step (solve + decreased error)
   template <typename X_t, typename AccFunc>
   std::pair<bool, std::optional<Vector<Scalar, Dims>>> Step(X_t &x, const AccFunc &acc,

--- a/tests/userdef_params_jet.cpp
+++ b/tests/userdef_params_jet.cpp
@@ -31,7 +31,7 @@ using namespace tinyopt::nlls;
 template <typename T>  // Template is only needed if you need automatic
                        // differentiation
 struct Rectangle {
-  using Scalar = T;               // The scalar type
+  using Scalar = T;           // The scalar type
   using Vec2 = Vector<T, 2>;  // Just for convenience
   Rectangle() : p1(Vec2::Zero()), p2(Vec2::Zero()) {}
   explicit Rectangle(const Vec2 &_p1, const Vec2 &_p2) : p1(_p1), p2(_p2) {}
@@ -47,13 +47,13 @@ struct Rectangle {
   // Returns the center of the rectangle
   Vec2 center() const { return T(0.5) * (p1 + p2); }
 
-  friend std::ostream& operator<<(std::ostream& os, const Rectangle& rect) {
+  friend std::ostream &operator<<(std::ostream &os, const Rectangle &rect) {
     os << "p1:" << rect.p1.transpose() << ", p2:" << rect.p2.transpose();
     return os;
   }
 
   Vector<T, Dynamic> p1;  // top left positions (with a dynamic vector to test this)
-  Vec2 p2;                              // bottom right positions
+  Vec2 p2;                // bottom right positions
 };
 
 namespace tinyopt::traits {
@@ -62,7 +62,7 @@ namespace tinyopt::traits {
 // to Optimize one.
 template <typename T>
 struct params_trait<Rectangle<T>> {
-  using Scalar = T;               // The scalar type
+  using Scalar = T;                 // The scalar type
   static constexpr Index Dims = 4;  // Compile-time parameters dimensions
 
   // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>, only used by
@@ -99,7 +99,7 @@ void TestUserDefinedParameters() {
   // the center at (1, 2).
 #if __cplusplus >= 202002L
   auto loss = [&]<typename T>(const Rectangle<T> &rect) {
-#else // c++17 and below
+#else  // c++17 and below
   auto loss = [&](const auto &rect) {
     using T = typename std::decay_t<decltype(rect)>::Scalar;
 #endif


### PR DESCRIPTION
With this work, you can create a Parameters Wrapper struct that does not copy external data.
This is the suggested way to optimize external data structs.


```cpp
template <typename MyPoses>
struct ParamsWrapper {
  static constexpr Index Dims = Dynamic;
  ParamsWrapper() = delete;
  ParamsWrapper(MyPoses &poses_) : poses{poses_} {}
  ParamsWrapper(MyPoses &&poses_) : poses{poses_} {}
  int dims() const { return poses.dims() ; }
  // Returns a copy where the scalar is converted to another type 'T2'.
  // This is only used by auto differentiation
  template <typename T2>
  inline auto cast() const {
    auto poses2 = poses.template cast<T2>(); // must be defined by MyPoses
    using MyPoses2 = std::decay_t<decltype(poses2)>;
    ParamsWrapper<MyPoses2> x2(std::move(poses2));
    return std::move(x2);
  }
  // Define update / manifold
  ParamsWrapper &operator+=(const auto &delta) {
    poses += delta; // must be defined by MyPoses
    return *this;
  }
  MyPoses &poses; // look Ma, no copy!
  // And you can add more parameters here, so fun!
};
// You can now optimize x and the poses will be updated
MyPoses poses;
...
Parameters<MyPoses> x(poses);
Optimize(x, loss);
``` 
