### PR TITLE
Allow AutoDiff with a sparse system

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,11 @@ as the problem size (not residuals!) increases as Ceres-Solver has nice tricks t
 
 Here is what is coming up. Don't trust too much the versions as I go with the flow.
 
-### v1 (stable API + Armadillo)
+### v1 (Stable API)
 
 - [ ] Add l-BFGS for large sparse problems
-- [ ] Native support of Armadillo (as alternative to Eigen)
-- [ ] Refactor Numerical/Automatic differentiation to support NLLS and general optimizations
 - [ ] Update all docs
+- [ ] Refactor Num/Auto differentiation using AutoDiff lib (support: sparse, unconstrained optimization)
 
 ### v1.x (Bindings)
 - [ ] Add C API
@@ -139,11 +138,13 @@ Here is what is coming up. Don't trust too much the versions as I go with the fl
 Also,
 - [ ] A wider array of benchmarks
 
-### v2 (Refactoring, Speed-ups & Many Solvers)
-- [ ] Speed-up compilation (e.g. c++20 Concepts)
+### v2 (Armadillo & Many Solvers)
+- [ ] Native support of Armadillo (as alternative to Eigen)
 - [ ] Refactor Solvers
-- [ ] Add various more solvers (CG, Adam, ...) and backend (e.g. Cuda)
-- [ ] Speed-up large problems (e.g. AMD)
+- [ ] Add more backends (e.g. nvcc, SuiteSparse, etc.)
+- [ ] Add more optimizers (CG, Adam, ...)
+- [ ] Speed-up large problems (AD to support very large sparse systems, move to autodiff?)
+- [ ] Speed-up compilation (e.g. c++20 Concepts)
 
 Ah ah, you thought I would use Jira for this list? No way.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -214,6 +214,52 @@ Optimize(rectangle, loss);
 // That's it, rectangle is now fitted to your loss
 ```
 
+### How to skip data copies?
+
+How do I create a parameters wrapper struct that uses external data sources without expensive copies?
+This way:
+
+```cpp
+
+template <typename MyPoses>
+struct ParamsWrapper {
+  static constexpr Index Dims = Dynamic;
+  ParamsWrapper() = delete;
+  ParamsWrapper(MyPoses &poses_) : poses{poses_} {}
+  ParamsWrapper(MyPoses &&poses_) : poses{poses_} {}
+
+  int dims() const { return poses2.size(); }
+
+  // Returns a copy where the scalar is converted to another type 'T2'.
+  // This is only used by auto differentiation
+  template <typename T2>
+  inline auto cast() const {
+    auto poses2 = poses.template cast<T2>(); // must be defined by MyPoses
+    using MyPoses2 = std::decay_t<decltype(poses2)>;
+    ParamsWrapper<MyPoses2> x2(std::move(poses2));
+    return std::move(x2);
+  }
+
+  // Define update / manifold
+  ParamsWrapper &operator+=(const auto &delta) {
+    poses += delta; // must be defined by MyPoses
+    return *this;
+  }
+
+  MyPoses &poses; // look Ma, no copy!
+  // And you can add more parameters here, so fun!
+  // Note: Avoid adding const data here.
+};
+
+// You can now optimize x and the poses will be updated
+MyPoses poses;
+...
+Parameters<MyPoses> x(poses);
+Optimize(x, loss);
+
+```
+Ok, there will be copies when using Auto Diff (which calls the `cast()` method), one per iteration.
+
 ### Numerical Differentiation
 Not all cost functions are the same. By default, `tinyopt` will try to use automatic differentiation
 when the function has only one parameter `x` but if your function does not allow it,

--- a/include/tinyopt/diff/optimize_autodiff.h
+++ b/include/tinyopt/diff/optimize_autodiff.h
@@ -41,15 +41,19 @@ inline auto OptimizeWithAutoDiff(X_t &X, const ResidualsFunc &residuals,
 
   // Construct the Jet
   using Jet = diff::Jet<Scalar, Dims>;
-  // XJetType is either of {Jet, Vector<Jet, N> or X_t::cast<Jet>()}
-  using XJetType = std::conditional_t<std::is_floating_point_v<X_t>, Jet,
-                                      decltype(ptrait::template cast<Jet>(X))>;
-  // DXJetType is either of {nullptr, Vector<Jet, Dims>, Matrix<Jet, Rows, Cols>}
-  using DXJetType = std::conditional_t<is_userdef_type, Vector<Jet, Dims>, std::nullptr_t>;
-  XJetType x_jet;
-  DXJetType dx_jet;  // only for user defined X type
 
-  // Copy X to Jet values
+  // Note: XJetType and DXJetType are only instantiated to avoid having to set the 'v's at each iteration
+
+  // Construct the Jet for scalar or Matrix, so {Jet, Vector<Jet, N> ot nullptr_t}
+  using XJetType = std::conditional_t<
+      std::is_floating_point_v<X_t>, Jet,
+      std::conditional_t<is_userdef_type, std::nullptr_t, decltype(ptrait::template cast<Jet>(X))>>;
+  XJetType x_jet;
+
+  // DXJetType is either of {Vector<Jet, Dims>, Matrix<Jet, Rows, Cols>, nullptr}
+  using DXJetType = std::conditional_t<is_userdef_type, Vector<Jet, Dims>, std::nullptr_t>;
+
+  DXJetType dx_jet;  // only for user defined X type
   if constexpr (is_userdef_type) {  // X is user defined object
     dx_jet = DXJetType::Zero(size);
     for (Index i = 0; i < size; ++i) {
@@ -73,25 +77,32 @@ inline auto OptimizeWithAutoDiff(X_t &X, const ResidualsFunc &residuals,
     }
   }
 
-  auto acc = [&](const auto &x, auto &grad, auto &H) {
-    using H_t = decltype(H);
-    constexpr bool HasGrad = !traits::is_nullptr_v<decltype(grad)>;
-    constexpr bool HasH = !traits::is_nullptr_v<H_t>;
-    // Update jet with latest 'x' values
-    if constexpr (is_userdef_type) {          // X is user defined object
-      x_jet = ptrait::template cast<Jet>(X);  // Cast X to a Jet type
-      using ptrait_jet = traits::params_trait<XJetType>;
+  // Update jet with latest 'x' values, either returning the 'x_jet' or a local copy for user defined types
+  auto update_x_jet = [&](const auto &x) {
+    if constexpr (is_userdef_type) {
+      auto x_jet = ptrait::template cast<Jet>(x);  // Cast X to a Jet type // TODO reduce copy
+      using ptrait_jet = traits::params_trait<std::decay_t<decltype(x_jet)>>;
       ptrait_jet::PlusEq(x_jet, dx_jet);
+      return std::move(x_jet);
     } else if constexpr (std::is_floating_point_v<X_t>) {  // X is scalar
       x_jet.a = x;
+      return x_jet;
     } else {  // X is a Vector or Matrix
       for (int c = 0; c < x.cols(); ++c) {
         for (int r = 0; r < x.rows(); ++r) {
           x_jet(r, c).a = x(r, c);
         }
       }
+      return x_jet;
     }
+  };
 
+  auto acc = [&](const auto &x, auto &grad, auto &H) {
+    using H_t = decltype(H);
+    constexpr bool HasGrad = !traits::is_nullptr_v<decltype(grad)>;
+    constexpr bool HasH = !traits::is_nullptr_v<H_t>;
+
+    const auto &x_jet = update_x_jet(x);
     // Retrieve the residuals
     const auto res = residuals(x_jet);
     using ResType = typename std::decay_t<decltype(res)>;

--- a/include/tinyopt/stop_reasons.h
+++ b/include/tinyopt/stop_reasons.h
@@ -27,15 +27,18 @@ enum StopReason : int {
    * @name Failures (negative enums)
    * @{
    */
+
   kOutOfMemory = -4,        ///< Out of memory when allocating the system (Hessian(s)
-  kSolverFailed = -3,       ///< Failed to solve the normal equations (H is not definite positive)
+  kSolverFailed = -3,       ///< Failed to solve the normal equations (H is not invertible)
   kSystemHasNaNOrInf = -2,  ///< Residuals or Jacobians have NaNs or Infinity
   kSkipped = -1,            ///< The system has no residuals or nothing to optimize or H is all 0s
-                            /** @} */
-                            /**
-                             * @name Success (positive enums or 0)
-                             * @{
-                             */
+
+  /** @} */
+  /**
+    * @name Success (positive enums or 0)
+    * @{
+    */
+
   kNone = 0,                ///< No stop, used by Step() or when no iterations done  (success)
   kMinError,                ///< Minimal error reached  (success)
   kMinRelError,             ///< Minimal relative error decrease reached (success)
@@ -46,6 +49,7 @@ enum StopReason : int {
   kMaxConsecNoDecr,         ///< Failed to decrease error consecutively too many times (success)
   kTimedOut,                ///< Total allocated time reached (success)
   kUserStopped              ///< User stopped the process (success)
+
   /** @} */
 };
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -152,10 +152,11 @@ void TestSuccess() {
 }
 
 /// Common checks on an early failure
-void FailureChecks(const auto &out, StopReason expected_stop = StopReason::kSolverFailed) {
+void FailureChecks(const auto &out, StopReason expected_stop = StopReason::kSolverFailed,
+                   int max_iters = 1) {
   REQUIRE(!out.Succeeded());
   REQUIRE(!out.Converged());
-  REQUIRE(out.num_iters <= 1);  // can at most tried once
+  REQUIRE(out.num_iters <= max_iters);  // can at most tried once
   REQUIRE(out.errs.empty());
   REQUIRE(out.successes.empty());
   REQUIRE(out.deltas2.empty());
@@ -235,7 +236,7 @@ void TestFailures() {
     gn::Options options;
     options.solver.check_min_H_diag = 1e-7f;
     const auto &out = gn::Optimize(x, loss, options);
-    FailureChecks(out, StopReason::kSkipped);
+    FailureChecks(out, StopReason::kSolverFailed, 3);
   }
   // No residuals
   {

--- a/tests/userdef_params_jet.cpp
+++ b/tests/userdef_params_jet.cpp
@@ -31,7 +31,7 @@ using namespace tinyopt::nlls;
 template <typename T>  // Template is only needed if you need automatic
                        // differentiation
 struct Rectangle {
-  using Scalar = T;               // The scalar type
+  using Scalar = T;           // The scalar type
   using Vec2 = Vector<T, 2>;  // Just for convenience
   Rectangle() : p1(Vec2::Zero()), p2(Vec2::Zero()) {}
   explicit Rectangle(const Vec2 &_p1, const Vec2 &_p2) : p1(_p1), p2(_p2) {}
@@ -47,13 +47,13 @@ struct Rectangle {
   // Returns the center of the rectangle
   Vec2 center() const { return T(0.5) * (p1 + p2); }
 
-  friend std::ostream& operator<<(std::ostream& os, const Rectangle& rect) {
+  friend std::ostream &operator<<(std::ostream &os, const Rectangle &rect) {
     os << "p1:" << rect.p1.transpose() << ", p2:" << rect.p2.transpose();
     return os;
   }
 
   Vector<T, Dynamic> p1;  // top left positions (with a dynamic vector to test this)
-  Vec2 p2;                              // bottom right positions
+  Vec2 p2;                // bottom right positions
 };
 
 namespace tinyopt::traits {
@@ -62,7 +62,7 @@ namespace tinyopt::traits {
 // to Optimize one.
 template <typename T>
 struct params_trait<Rectangle<T>> {
-  using Scalar = T;               // The scalar type
+  using Scalar = T;                 // The scalar type
   static constexpr Index Dims = 4;  // Compile-time parameters dimensions
 
   // Convert a Rectangle to another type 'T2', e.g. T2 = Jet<T>, only used by
@@ -99,7 +99,7 @@ void TestUserDefinedParameters() {
   // the center at (1, 2).
 #if __cplusplus >= 202002L
   auto loss = [&]<typename T>(const Rectangle<T> &rect) {
-#else // c++17 and below
+#else  // c++17 and below
   auto loss = [&](const auto &rect) {
     using T = typename std::decay_t<decltype(rect)>::Scalar;
 #endif


### PR DESCRIPTION
This PR allows you to use automatic differentiation with a sparse solver.
You can use it this way:

```cpp
auto loss = [&](const auto &x) {
    using T = std::decay_t<decltype(x)>::Scalar;
    return (T(10) * x.array() - T(2)).matrix().eval();
  };

  VecXf x = VecXf::Random(100);
  Options options;
  options.log.print_x = false; // x is really long!
  using Optimizer = Optimizer<SparseMatrix<float>>;
  Optimizer optimizer(options);
  optimizer(x, loss);
```

NOTE: It compiles and converge, hopefully, but if your system is really big, it is not memory friendly for now because
* the AutoDiff (Jet) stores the dense Jacobian. (maybe time to move to using AutoDiff library?)
* the OptimizeWithAutoDiff function makes another copy of the dense jacobian before filling H = Jt*J. (that an easier fix)

...so there's room for improvements and memory/cpu savings but at least it runs (well if you got a big enough RAM)!