### PR TITLE
chore: Add pre-commit config for hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8  # Use the latest version tag
+    hooks:
+    -   id: clang-format
+        types_or: [c, c++, c#, cuda, java, javascript, json, objective-c, proto, textproto]


### PR DESCRIPTION
To use it:
Install pre-commit:
`pip install pre-commit`

Install the hook into Git:
`pre-commit install`